### PR TITLE
Add relationship annotation support and tests

### DIFF
--- a/core/src/main/java/org/db2code/extractors/TableExtractor.java
+++ b/core/src/main/java/org/db2code/extractors/TableExtractor.java
@@ -49,6 +49,7 @@ public class TableExtractor extends AbstractExtractor<DatabaseExtractionParamete
 
                 rawTable.setPrimaryKey(extractPrimaryKeys(databaseMetaData, rawTable));
                 rawTable.setForeignKeys(extractForeignKeys(databaseMetaData, rawTable));
+                rawTable.setImportedKeys(extractImportedKeys(databaseMetaData, rawTable));
                 setColumns(databaseMetaData, params, rawTable);
                 results.add(rawTable);
             }
@@ -90,6 +91,33 @@ public class TableExtractor extends AbstractExtractor<DatabaseExtractionParamete
                 rawForeignKey = new RawForeignKey();
                 for (ExportedKeyMetadata mdItem : ExportedKeyMetadata.values()) {
                     Object mdValue = exportedKeys.getObject(mdItem.name());
+                    String propName =
+                            JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(mdItem.name());
+                    setProperty(rawForeignKey, mdValue, propName);
+                }
+                fkResults.add(rawForeignKey);
+            }
+
+            if (rawForeignKey != null) {
+                rawForeignKey.setIsLast(true);
+            }
+            return fkResults;
+        }
+    }
+
+    private List<RawForeignKey> extractImportedKeys(
+            DatabaseMetaData databaseMetaData, RawTable rawTable) throws SQLException {
+        List<RawForeignKey> fkResults = new ArrayList<>();
+        try (ResultSet importedKeys =
+                databaseMetaData.getImportedKeys(
+                        rawTable.getTableCat(),
+                        rawTable.getTableSchem(),
+                        rawTable.getTableName())) {
+            RawForeignKey rawForeignKey = null;
+            while (importedKeys.next()) {
+                rawForeignKey = new RawForeignKey();
+                for (ExportedKeyMetadata mdItem : ExportedKeyMetadata.values()) {
+                    Object mdValue = importedKeys.getObject(mdItem.name());
                     String propName =
                             JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(mdItem.name());
                     setProperty(rawForeignKey, mdValue, propName);

--- a/core/src/main/java/org/db2code/rawmodel/RawTable.java
+++ b/core/src/main/java/org/db2code/rawmodel/RawTable.java
@@ -18,7 +18,8 @@ public class RawTable extends AbstractRawTableItem {
     private Collection<RawColumn> columns = new ArrayList<>();
 
     private Collection<RawPrimaryKey> primaryKey = new ArrayList<>();
-    private Collection<RawForeignKey> foreignKeys;
+    private Collection<RawForeignKey> foreignKeys = new ArrayList<>();
+    private Collection<RawForeignKey> importedKeys = new ArrayList<>();
 
     @Data
     @ToString(callSuper = true)

--- a/core/src/test/resources/generic-case/sample-assert.json
+++ b/core/src/test/resources/generic-case/sample-assert.json
@@ -66,6 +66,20 @@
           "isNullable": "NO"
         },
         {
+          "tableCat": "TEST",
+          "tableSchem": "TEST_SCHEMA",
+          "tableName": "TEST_TABLE_1",
+          "columnName": "SOME_BOOL",
+          "dataType": 16,
+          "typeName": "BOOLEAN",
+          "columnSize": 1,
+          "decimalDigits": 0,
+          "nullable": 1,
+          "charOctetLength": 1,
+          "ordinalPosition": 5,
+          "isNullable": "YES"
+        },
+        {
           "isLast": true,
           "tableCat": "TEST",
           "tableSchem": "TEST_SCHEMA",
@@ -77,7 +91,7 @@
           "decimalDigits": 6,
           "nullable": 0,
           "charOctetLength": 26,
-          "ordinalPosition": 5,
+          "ordinalPosition": 6,
           "isNullable": "NO"
         }
       ],
@@ -101,7 +115,7 @@
           "fktableCat": "TEST",
           "fktableSchem": "TEST_SCHEMA",
           "fktableName": "TEST_TABLE_2",
-          "fkcolumnName": "SIMPLE_ID_2",
+          "fkcolumnName": "SIMPLE_ID_1",
           "keySeq": 1,
           "updateRule": 1,
           "deleteRule": 1,
@@ -121,7 +135,7 @@
           "keySeq": 1,
           "updateRule": 1,
           "deleteRule": 1,
-          "fkName": "CONSTRAINT_DCFE",
+          "fkName": "CONSTRAINT_DCFE4",
           "pkName": "CONSTRAINT_D",
           "deferrability": 7,
           "isLast": true
@@ -154,6 +168,21 @@
           "tableCat": "TEST",
           "tableSchem": "TEST_SCHEMA",
           "tableName": "TEST_TABLE_2",
+          "columnName": "SIMPLE_ID_1",
+          "dataType": 4,
+          "typeName": "INTEGER",
+          "columnSize": 32,
+          "decimalDigits": 0,
+          "numPrecRadix": 2,
+          "nullable": 0,
+          "charOctetLength": 32,
+          "ordinalPosition": 2,
+          "isNullable": "NO"
+        },
+        {
+          "tableCat": "TEST",
+          "tableSchem": "TEST_SCHEMA",
+          "tableName": "TEST_TABLE_2",
           "columnName": "TEST_VARCHAR",
           "dataType": 12,
           "typeName": "CHARACTER VARYING",
@@ -161,7 +190,7 @@
           "decimalDigits": 0,
           "nullable": 1,
           "charOctetLength": 50,
-          "ordinalPosition": 2,
+          "ordinalPosition": 3,
           "isNullable": "YES"
         },
         {
@@ -176,7 +205,7 @@
           "numPrecRadix": 10,
           "nullable": 1,
           "charOctetLength": 10,
-          "ordinalPosition": 3,
+          "ordinalPosition": 4,
           "isNullable": "YES"
         },
         {
@@ -190,7 +219,7 @@
           "decimalDigits": 0,
           "nullable": 1,
           "charOctetLength": 10,
-          "ordinalPosition": 4,
+          "ordinalPosition": 5,
           "isNullable": "YES"
         },
         {
@@ -205,7 +234,7 @@
           "decimalDigits": 6,
           "nullable": 1,
           "charOctetLength": 26,
-          "ordinalPosition": 5,
+          "ordinalPosition": 6,
           "isNullable": "YES"
         }
       ],
@@ -233,7 +262,7 @@
           "keySeq": 1,
           "updateRule": 1,
           "deleteRule": 1,
-          "fkName": "CONSTRAINT_DCFE4",
+          "fkName": "CONSTRAINT_DCFE4D",
           "pkName": "CONSTRAINT_DC",
           "deferrability": 7,
           "isLast": true
@@ -250,7 +279,7 @@
           "tableCat": "TEST",
           "tableSchem": "TEST_SCHEMA",
           "tableName": "TEST_TABLE_3",
-          "columnName": "SIMPLE_ID_1",
+          "columnName": "SIMPLE_ID_3",
           "dataType": 4,
           "typeName": "INTEGER",
           "columnSize": 32,
@@ -259,6 +288,21 @@
           "nullable": 0,
           "charOctetLength": 32,
           "ordinalPosition": 1,
+          "isNullable": "NO"
+        },
+        {
+          "tableCat": "TEST",
+          "tableSchem": "TEST_SCHEMA",
+          "tableName": "TEST_TABLE_3",
+          "columnName": "SIMPLE_ID_1",
+          "dataType": 4,
+          "typeName": "INTEGER",
+          "columnSize": 32,
+          "decimalDigits": 0,
+          "numPrecRadix": 2,
+          "nullable": 0,
+          "charOctetLength": 32,
+          "ordinalPosition": 2,
           "isNullable": "NO"
         },
         {
@@ -274,11 +318,21 @@
           "numPrecRadix": 2,
           "nullable": 0,
           "charOctetLength": 32,
-          "ordinalPosition": 2,
+          "ordinalPosition": 3,
           "isNullable": "NO"
         }
       ],
-      "primaryKey": [],
+      "primaryKey": [
+        {
+          "isLast": true,
+          "tableCat": "TEST",
+          "tableSchem": "TEST_SCHEMA",
+          "tableName": "TEST_TABLE_3",
+          "columnName": "SIMPLE_ID_3",
+          "keySeq": "1",
+          "pkName": "CONSTRAINT_DCFE"
+        }
+      ],
       "foreignKeys": []
     }
   ],

--- a/core/src/test/resources/generic-case/sample.sql
+++ b/core/src/test/resources/generic-case/sample.sql
@@ -2,25 +2,28 @@ CREATE SCHEMA IF NOT EXISTS test_schema;
 SET SCHEMA test_schema;
 
 CREATE TABLE IF NOT EXISTS test_schema.test_table_1 (
-    simple_id_1 INT PRIMARY KEY,
+    simple_id_1 INT AUTO_INCREMENT PRIMARY KEY,
     test_varchar VARCHAR(50) NOT NULL,
     test_numeric NUMERIC(10,2) NOT NULL,
     test_date DATE NOT NULL,
+    some_bool BOOLEAN,
     test_datetime TIMESTAMP NOT NULL
 );
 COMMENT ON TABLE test_schema.test_table_1 IS 'test_table_1 description';
 
 CREATE TABLE IF NOT EXISTS test_schema.test_table_2 (
-    simple_id_2 INT PRIMARY KEY,
+    simple_id_2 INT AUTO_INCREMENT PRIMARY KEY,
+    simple_id_1 INT NOT NULL,
     test_varchar VARCHAR(50),
     test_numeric NUMERIC(10,2),
     test_date DATE,
     test_datetime TIMESTAMP,
-  FOREIGN KEY (simple_id_2) REFERENCES test_schema.test_table_1(simple_id_1)
+  FOREIGN KEY (simple_id_1) REFERENCES test_schema.test_table_1(simple_id_1)
 );
 COMMENT ON COLUMN test_schema.test_table_2.simple_id_2 IS 'this is table2 id';
 
 CREATE TABLE IF NOT EXISTS test_schema.test_table_3 (
+    simple_id_3 INT AUTO_INCREMENT PRIMARY KEY,
     simple_id_1 INT NOT NULL,
     simple_id_2 INT NOT NULL,
    FOREIGN KEY (simple_id_1) REFERENCES test_schema.test_table_1(simple_id_1),

--- a/core/src/test/resources/generic-case/table-filter.json
+++ b/core/src/test/resources/generic-case/table-filter.json
@@ -66,6 +66,20 @@
           "isNullable": "NO"
         },
         {
+          "tableCat": "TEST",
+          "tableSchem": "TEST_SCHEMA",
+          "tableName": "TEST_TABLE_1",
+          "columnName": "SOME_BOOL",
+          "dataType": 16,
+          "typeName": "BOOLEAN",
+          "columnSize": 1,
+          "decimalDigits": 0,
+          "nullable": 1,
+          "charOctetLength": 1,
+          "ordinalPosition": 5,
+          "isNullable": "YES"
+        },
+        {
           "isLast": true,
           "tableCat": "TEST",
           "tableSchem": "TEST_SCHEMA",
@@ -77,7 +91,7 @@
           "decimalDigits": 6,
           "nullable": 0,
           "charOctetLength": 26,
-          "ordinalPosition": 5,
+          "ordinalPosition": 6,
           "isNullable": "NO"
         }
       ],
@@ -101,7 +115,7 @@
           "fktableCat": "TEST",
           "fktableSchem": "TEST_SCHEMA",
           "fktableName": "TEST_TABLE_2",
-          "fkcolumnName": "SIMPLE_ID_2",
+          "fkcolumnName": "SIMPLE_ID_1",
           "keySeq": 1,
           "updateRule": 1,
           "deleteRule": 1,
@@ -121,7 +135,7 @@
           "keySeq": 1,
           "updateRule": 1,
           "deleteRule": 1,
-          "fkName": "CONSTRAINT_DCFE",
+          "fkName": "CONSTRAINT_DCFE4",
           "pkName": "CONSTRAINT_D",
           "deferrability": 7,
           "isLast": true

--- a/java-pojo-generator-mojo-example/hibernate.mustache
+++ b/java-pojo-generator-mojo-example/hibernate.mustache
@@ -1,0 +1,50 @@
+package {{package}};
+
+import jakarta.persistence.*;
+import java.util.List;
+
+/** {{rawTable.remarks}}
+{{rawTable.tableCat}}.{{rawTable.tableSchem}}.{{rawTable.tableName}}{{#generationInfo}}
+
+    {{generationInfo}}{{/generationInfo}}
+*/
+@Entity
+@Table(schema = "{{rawTable.tableSchem}}", name = "{{rawTable.tableName}}")
+public class {{className}} {
+{{#properties}}
+
+    {{#isRelational}}
+        {{#isManyToOne}}
+            @ManyToOne
+            @JoinColumn(name = "{{rawColumn.columnName}}") {{^isNullable}}@jakarta.validation.constraints.NotNull{{/isNullable}}
+            private {{propertyType}} {{propertyName}};
+        {{/isManyToOne}}
+        {{#isOneToMany}}
+            @OneToMany(mappedBy = "{{mappedBy}}", cascade = CascadeType.ALL, orphanRemoval = true)
+            private List<{{propertyType}}> {{propertyName}};
+        {{/isOneToMany}}
+    {{/isRelational}}
+    {{^isRelational}}
+    /** {{rawColumn.remarks}}
+    {{rawColumn.columnName}} {{rawColumn.typeName}}({{rawColumn.columnSize}}) Nullable={{rawColumn.isNullable}}
+    */
+    @Column("{{rawColumn.columnName}}") {{#isId}}@Id @GeneratedValue(strategy = GenerationType.IDENTITY){{/isId}}{{^isNullable}}
+
+        @jakarta.validation.constraints.NotNull{{/isNullable}}{{#size}}
+
+        @jakarta.validation.constraints.Size(max = {{size}}){{/size}}
+    private {{propertyType}} {{propertyName}};
+    {{/isRelational}}
+{{/properties}}
+{{#properties}}
+
+    public {{propertyType}} get{{methodName}}() {
+    return {{propertyName}};
+    }
+
+    public void set{{methodName}}({{propertyType}} {{propertyName}}) {
+    this.{{propertyName}} = {{propertyName}};
+    }
+
+{{/properties}}
+}

--- a/java-pojo-generator-mojo-example/init.sql
+++ b/java-pojo-generator-mojo-example/init.sql
@@ -1,34 +1,33 @@
 CREATE SCHEMA IF NOT EXISTS test_schema;
 SET SCHEMA test_schema;
 
-CREATE TABLE IF NOT EXISTS test_schema.test_table_1
-(
-    simple_id_1   INT AUTO_INCREMENT PRIMARY KEY,
-    test_varchar  VARCHAR(50)    NOT NULL,
-    test_numeric  NUMERIC(10, 2) NOT NULL,
-    test_date     DATE           NOT NULL,
-    some_bool     BOOLEAN                ,
-    test_datetime TIMESTAMP      NOT NULL
+CREATE TABLE IF NOT EXISTS test_schema.test_table_1 (
+    simple_id_1 INT AUTO_INCREMENT PRIMARY KEY,
+    test_varchar VARCHAR(50) NOT NULL,
+    test_numeric NUMERIC(10,2) NOT NULL,
+    test_date DATE NOT NULL,
+    some_bool BOOLEAN,
+    test_datetime TIMESTAMP NOT NULL
 );
 COMMENT ON TABLE test_schema.test_table_1 IS 'test_table_1 description';
 
-CREATE TABLE IF NOT EXISTS test_schema.test_table_2
-(
-    simple_id_2   INT AUTO_INCREMENT PRIMARY KEY,
-    test_varchar  VARCHAR(50),
-    test_numeric  NUMERIC(10, 2),
-    test_date     DATE,
+CREATE TABLE IF NOT EXISTS test_schema.test_table_2 (
+    simple_id_2 INT AUTO_INCREMENT PRIMARY KEY,
+    simple_id_1 INT NOT NULL,
+    test_varchar VARCHAR(50),
+    test_numeric NUMERIC(10,2),
+    test_date DATE,
     test_datetime TIMESTAMP,
-    FOREIGN KEY (simple_id_2) REFERENCES test_schema.test_table_1 (simple_id_1)
+  FOREIGN KEY (simple_id_1) REFERENCES test_schema.test_table_1(simple_id_1)
 );
 COMMENT ON COLUMN test_schema.test_table_2.simple_id_2 IS 'this is table2 id';
 
-CREATE TABLE IF NOT EXISTS test_schema.test_table_3
-(
+CREATE TABLE IF NOT EXISTS test_schema.test_table_3 (
+    simple_id_3 INT AUTO_INCREMENT PRIMARY KEY,
     simple_id_1 INT NOT NULL,
     simple_id_2 INT NOT NULL,
-    FOREIGN KEY (simple_id_1) REFERENCES test_schema.test_table_1 (simple_id_1),
-    FOREIGN KEY (simple_id_2) REFERENCES test_schema.test_table_2 (simple_id_2)
+   FOREIGN KEY (simple_id_1) REFERENCES test_schema.test_table_1(simple_id_1),
+   FOREIGN KEY (simple_id_2) REFERENCES test_schema.test_table_2(simple_id_2)
 );
 
 CREATE ALIAS IF NOT EXISTS NEXT_PRIME AS '

--- a/java-pojo-generator-mojo-example/pom.xml
+++ b/java-pojo-generator-mojo-example/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
             <version>${spring-boot.version}</version>
@@ -59,6 +64,18 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>6.2.4.Final</version>
+        </dependency>
+
+        <!-- Jakarta Persistence API -->
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.1.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable1.java
+++ b/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable1.java
@@ -1,0 +1,82 @@
+package hibernate.testpkg;
+
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "TEST_TABLE_1")
+public class TestTable1 {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer simpleId1;
+
+    @OneToMany(mappedBy = "testTable1", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TestTable3> testTable3List;
+
+    private String testVarchar;
+
+    private java.math.BigDecimal testNumeric;
+
+    private java.util.Date testDate;
+
+    private Boolean someBool;
+
+    private java.time.LocalDateTime testDatetime;
+
+    public List<TestTable3> getTestTable3List() {
+        return testTable3List;
+    }
+
+    public void setTestTable3List(List<TestTable3> testTable3List) {
+        this.testTable3List = testTable3List;
+    }
+
+    public Integer getSimpleId1() {
+        return simpleId1;
+    }
+
+    public void setSimpleId1(Integer simpleId1) {
+        this.simpleId1 = simpleId1;
+    }
+
+    public String getTestVarchar() {
+        return testVarchar;
+    }
+
+    public void setTestVarchar(String testVarchar) {
+        this.testVarchar = testVarchar;
+    }
+
+    public java.math.BigDecimal getTestNumeric() {
+        return testNumeric;
+    }
+
+    public void setTestNumeric(java.math.BigDecimal testNumeric) {
+        this.testNumeric = testNumeric;
+    }
+
+    public java.util.Date getTestDate() {
+        return testDate;
+    }
+
+    public void setTestDate(java.util.Date testDate) {
+        this.testDate = testDate;
+    }
+
+    public Boolean getSomeBool() {
+        return someBool;
+    }
+
+    public void setSomeBool(Boolean someBool) {
+        this.someBool = someBool;
+    }
+
+    public java.time.LocalDateTime getTestDatetime() {
+        return testDatetime;
+    }
+
+    public void setTestDatetime(java.time.LocalDateTime testDatetime) {
+        this.testDatetime = testDatetime;
+    }
+}

--- a/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable1Repository.java
+++ b/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable1Repository.java
@@ -1,0 +1,7 @@
+package hibernate.testpkg;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestTable1Repository extends JpaRepository<TestTable1, Integer> {}

--- a/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable2.java
+++ b/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable2.java
@@ -1,0 +1,84 @@
+package hibernate.testpkg;
+
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "TEST_TABLE_2")
+public class TestTable2 {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer simpleId2;
+
+    private String testVarchar;
+
+    private java.math.BigDecimal testNumeric;
+
+    private java.util.Date testDate;
+
+    private java.time.LocalDateTime testDatetime;
+
+    @OneToMany(mappedBy = "testTable2", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TestTable3> testTable3List;
+
+    @ManyToOne
+    @JoinColumn(name = "simple_id_1")
+    private TestTable1 testTable1;
+
+    public Integer getSimpleId2() {
+        return simpleId2;
+    }
+
+    public void setSimpleId2(Integer simpleId2) {
+        this.simpleId2 = simpleId2;
+    }
+
+    public String getTestVarchar() {
+        return testVarchar;
+    }
+
+    public void setTestVarchar(String testVarchar) {
+        this.testVarchar = testVarchar;
+    }
+
+    public java.math.BigDecimal getTestNumeric() {
+        return testNumeric;
+    }
+
+    public void setTestNumeric(java.math.BigDecimal testNumeric) {
+        this.testNumeric = testNumeric;
+    }
+
+    public java.util.Date getTestDate() {
+        return testDate;
+    }
+
+    public void setTestDate(java.util.Date testDate) {
+        this.testDate = testDate;
+    }
+
+    public java.time.LocalDateTime getTestDatetime() {
+        return testDatetime;
+    }
+
+    public void setTestDatetime(java.time.LocalDateTime testDatetime) {
+        this.testDatetime = testDatetime;
+    }
+
+    public List<TestTable3> getTestTable3List() {
+        return testTable3List;
+    }
+
+    public void setTestTable3List(List<TestTable3> testTable3List) {
+        this.testTable3List = testTable3List;
+    }
+
+    public TestTable1 getTestTable1() {
+        return testTable1;
+    }
+
+    public void setTestTable1(TestTable1 testTable1) {
+        this.testTable1 = testTable1;
+    }
+}

--- a/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable2Repository.java
+++ b/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable2Repository.java
@@ -1,0 +1,7 @@
+package hibernate.testpkg;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestTable2Repository extends JpaRepository<TestTable2, Integer> {}

--- a/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable3.java
+++ b/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable3.java
@@ -1,0 +1,44 @@
+package hibernate.testpkg;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "TEST_TABLE_3")
+public class TestTable3 {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer simpleId3;
+
+    @ManyToOne
+    @JoinColumn(name = "simple_id_1")
+    private TestTable1 testTable1;
+
+    @ManyToOne
+    @JoinColumn(name = "simple_id_2")
+    private TestTable2 testTable2;
+
+    public Integer getSimpleId3() {
+        return simpleId3;
+    }
+
+    public void setSimpleId3(Integer simpleId3) {
+        this.simpleId3 = simpleId3;
+    }
+
+    public TestTable1 getTestTable1() {
+        return testTable1;
+    }
+
+    public void setTestTable1(TestTable1 testTable1) {
+        this.testTable1 = testTable1;
+    }
+
+    public TestTable2 getTestTable2() {
+        return testTable2;
+    }
+
+    public void setTestTable2(TestTable2 testTable2) {
+        this.testTable2 = testTable2;
+    }
+}

--- a/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable3Repository.java
+++ b/java-pojo-generator-mojo-example/src/main/java/hibernate/testpkg/TestTable3Repository.java
@@ -1,0 +1,7 @@
+package hibernate.testpkg;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestTable3Repository extends JpaRepository<TestTable3, Integer> {}

--- a/java-pojo-generator-mojo-example/src/main/resources/application.properties
+++ b/java-pojo-generator-mojo-example/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.datasource.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'init.sql'
 spring.datasource.driverClassName=org.h2.Driver
+logging.level.org = DEBUG

--- a/java-pojo-generator-mojo-example/src/test/java/hibernate/testpkg/App.java
+++ b/java-pojo-generator-mojo-example/src/test/java/hibernate/testpkg/App.java
@@ -1,0 +1,6 @@
+package hibernate.testpkg;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class App {}

--- a/java-pojo-generator-mojo-example/src/test/java/hibernate/testpkg/HibernateGenerationTest.java
+++ b/java-pojo-generator-mojo-example/src/test/java/hibernate/testpkg/HibernateGenerationTest.java
@@ -1,11 +1,11 @@
 package hibernate.testpkg;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = {App.class})
 @Transactional
@@ -15,7 +15,10 @@ public class HibernateGenerationTest {
     private final TestTable2Repository testTable2Repository;
     private final TestTable3Repository testTable3Repository;
 
-    public HibernateGenerationTest(@Autowired TestTable1Repository testTable1Repository, @Autowired TestTable2Repository testTable2Repository, @Autowired TestTable3Repository testTable3Repository) {
+    public HibernateGenerationTest(
+            @Autowired TestTable1Repository testTable1Repository,
+            @Autowired TestTable2Repository testTable2Repository,
+            @Autowired TestTable3Repository testTable3Repository) {
         this.testTable1Repository = testTable1Repository;
         this.testTable2Repository = testTable2Repository;
         this.testTable3Repository = testTable3Repository;

--- a/java-pojo-generator-mojo-example/src/test/java/hibernate/testpkg/HibernateGenerationTest.java
+++ b/java-pojo-generator-mojo-example/src/test/java/hibernate/testpkg/HibernateGenerationTest.java
@@ -1,0 +1,47 @@
+package hibernate.testpkg;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(classes = {App.class})
+@Transactional
+public class HibernateGenerationTest {
+
+    private final TestTable1Repository testTable1Repository;
+    private final TestTable2Repository testTable2Repository;
+    private final TestTable3Repository testTable3Repository;
+
+    public HibernateGenerationTest(@Autowired TestTable1Repository testTable1Repository, @Autowired TestTable2Repository testTable2Repository, @Autowired TestTable3Repository testTable3Repository) {
+        this.testTable1Repository = testTable1Repository;
+        this.testTable2Repository = testTable2Repository;
+        this.testTable3Repository = testTable3Repository;
+    }
+
+    @Test
+    public void test() throws Exception {
+        TestTable1 table1 = new TestTable1();
+        table1.setTestVarchar("t1");
+        table1 = testTable1Repository.save(table1);
+
+        TestTable2 table2 = new TestTable2();
+        table2.setTestVarchar("t2");
+        table2 = testTable2Repository.save(table2);
+
+        TestTable3 table3 = new TestTable3();
+        table3.setTestTable2(table2);
+        table3.setTestTable1(table1);
+        table3 = testTable3Repository.save(table3);
+
+        table2.setTestTable1(table1);
+        table2 = testTable2Repository.save(table2);
+
+        TestTable3 loadedTable3 = testTable3Repository.findById(table3.getSimpleId3()).get();
+        assertEquals("t1", loadedTable3.getTestTable1().getTestVarchar());
+        assertEquals("t2", loadedTable3.getTestTable2().getTestVarchar());
+        assertEquals("t1", loadedTable3.getTestTable2().getTestTable1().getTestVarchar());
+    }
+}

--- a/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/DatabaseAdapter.java
+++ b/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/DatabaseAdapter.java
@@ -60,7 +60,8 @@ public class DatabaseAdapter {
                                                 params.getTypeMapFile(),
                                                 params.isIncludeGenerationInfo(),
                                                 params.getGeneratorTarget().getPrefix(),
-                                                params.getGeneratorTarget().getSuffix()))
+                                                params.getGeneratorTarget().getSuffix(),
+                                                rawDatabaseMetadata.getTables()))
                         .collect(Collectors.toList());
         setIsLast(tableClassList);
         return tableClassList;

--- a/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/DefaultClassAdapter.java
+++ b/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/DefaultClassAdapter.java
@@ -9,8 +9,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.db2code.convert.JavaPropertyConverter;
-import org.db2code.rawmodel.RawTable;
 import org.db2code.rawmodel.RawForeignKey;
+import org.db2code.rawmodel.RawTable;
 
 public class DefaultClassAdapter implements ClassAdapter {
     private final RawTable rawTable;
@@ -134,31 +134,51 @@ public class DefaultClassAdapter implements ClassAdapter {
 
     private Collection<RelationAdapter> initOneToManyRelations() {
         List<RelationAdapter> results = new ArrayList<>();
-        rawTable.getForeignKeys().forEach(fk -> {
-            String className =
-                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(fk.getFktableName());
-            String fieldName =
-                    JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(fk.getFktableName())
-                            + "List";
-            String methodName =
-                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(fk.getFktableName())
-                            + "List";
-            results.add(new RelationAdapter(className, fieldName, methodName, fk.getFkcolumnName()));
-        });
+        rawTable.getForeignKeys()
+                .forEach(
+                        fk -> {
+                            String className =
+                                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(
+                                            fk.getFktableName());
+                            String fieldName =
+                                    JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(
+                                                    fk.getFktableName())
+                                            + "List";
+                            String methodName =
+                                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(
+                                                    fk.getFktableName())
+                                            + "List";
+                            results.add(
+                                    new RelationAdapter(
+                                            className,
+                                            fieldName,
+                                            methodName,
+                                            fk.getFkcolumnName()));
+                        });
         return results;
     }
 
     private Collection<RelationAdapter> initManyToOneRelations() {
         List<RelationAdapter> results = new ArrayList<>();
-        rawTable.getImportedKeys().forEach(fk -> {
-            String className =
-                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(fk.getPktableName());
-            String fieldName =
-                    JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(fk.getPktableName());
-            String methodName =
-                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(fk.getPktableName());
-            results.add(new RelationAdapter(className, fieldName, methodName, fk.getFkcolumnName()));
-        });
+        rawTable.getImportedKeys()
+                .forEach(
+                        fk -> {
+                            String className =
+                                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(
+                                            fk.getPktableName());
+                            String fieldName =
+                                    JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(
+                                            fk.getPktableName());
+                            String methodName =
+                                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(
+                                            fk.getPktableName());
+                            results.add(
+                                    new RelationAdapter(
+                                            className,
+                                            fieldName,
+                                            methodName,
+                                            fk.getFkcolumnName()));
+                        });
         return results;
     }
 
@@ -173,13 +193,9 @@ public class DefaultClassAdapter implements ClassAdapter {
                 RawForeignKey fk2 = importedList.get(1);
                 if (!fk1.getPktableName().equalsIgnoreCase(fk2.getPktableName())) {
                     if (fk1.getPktableName().equalsIgnoreCase(rawTable.getTableName())) {
-                        results.add(
-                                createManyToManyRelation(
-                                        fk1, fk2, table.getTableName()));
+                        results.add(createManyToManyRelation(fk1, fk2, table.getTableName()));
                     } else if (fk2.getPktableName().equalsIgnoreCase(rawTable.getTableName())) {
-                        results.add(
-                                createManyToManyRelation(
-                                        fk2, fk1, table.getTableName()));
+                        results.add(createManyToManyRelation(fk2, fk1, table.getTableName()));
                     }
                 }
             }

--- a/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/DefaultClassAdapter.java
+++ b/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/DefaultClassAdapter.java
@@ -1,13 +1,16 @@
 package org.db2code.generator.java.pojo.adapter;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.db2code.convert.JavaPropertyConverter;
 import org.db2code.rawmodel.RawTable;
+import org.db2code.rawmodel.RawForeignKey;
 
 public class DefaultClassAdapter implements ClassAdapter {
     private final RawTable rawTable;
@@ -15,6 +18,9 @@ public class DefaultClassAdapter implements ClassAdapter {
     private final boolean includeGenerationInfo;
 
     private final Collection<PropertyAdapter> properties;
+    private final Collection<RelationAdapter> oneToManyRelations;
+    private final Collection<RelationAdapter> manyToOneRelations;
+    private final Collection<ManyToManyRelationAdapter> manyToManyRelations;
     private final Set<String> uniqueProperties = new HashSet<>();
 
     private final Function<String, Boolean> propertyNamesUniquenessChecker =
@@ -36,13 +42,17 @@ public class DefaultClassAdapter implements ClassAdapter {
             String typeMapFile,
             boolean includeGenerationInfo,
             String prefix,
-            String suffix) {
+            String suffix,
+            Collection<RawTable> allTables) {
         this.rawTable = rawTable;
         this.targetPackage = targetPackage;
         this.includeGenerationInfo = includeGenerationInfo;
         this.prefix = prefix;
         this.suffix = suffix;
         properties = initProperties(rawTable, dateImpl, typeMapFile);
+        oneToManyRelations = initOneToManyRelations();
+        manyToOneRelations = initManyToOneRelations();
+        manyToManyRelations = initManyToManyRelations(allTables);
     }
 
     private Collection<PropertyAdapter> initProperties(
@@ -96,6 +106,18 @@ public class DefaultClassAdapter implements ClassAdapter {
         return properties;
     }
 
+    public Collection<RelationAdapter> getOneToManyRelations() {
+        return oneToManyRelations;
+    }
+
+    public Collection<RelationAdapter> getManyToOneRelations() {
+        return manyToOneRelations;
+    }
+
+    public Collection<ManyToManyRelationAdapter> getManyToManyRelations() {
+        return manyToManyRelations;
+    }
+
     @Override
     public String getGenerationInfo() {
         if (includeGenerationInfo) {
@@ -108,5 +130,79 @@ public class DefaultClassAdapter implements ClassAdapter {
     @Override
     public void setLast(boolean last) {
         this.rawTable.setIsLast(last);
+    }
+
+    private Collection<RelationAdapter> initOneToManyRelations() {
+        List<RelationAdapter> results = new ArrayList<>();
+        rawTable.getForeignKeys().forEach(fk -> {
+            String className =
+                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(fk.getFktableName());
+            String fieldName =
+                    JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(fk.getFktableName())
+                            + "List";
+            String methodName =
+                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(fk.getFktableName())
+                            + "List";
+            results.add(new RelationAdapter(className, fieldName, methodName, fk.getFkcolumnName()));
+        });
+        return results;
+    }
+
+    private Collection<RelationAdapter> initManyToOneRelations() {
+        List<RelationAdapter> results = new ArrayList<>();
+        rawTable.getImportedKeys().forEach(fk -> {
+            String className =
+                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(fk.getPktableName());
+            String fieldName =
+                    JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(fk.getPktableName());
+            String methodName =
+                    JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(fk.getPktableName());
+            results.add(new RelationAdapter(className, fieldName, methodName, fk.getFkcolumnName()));
+        });
+        return results;
+    }
+
+    private Collection<ManyToManyRelationAdapter> initManyToManyRelations(
+            Collection<RawTable> allTables) {
+        List<ManyToManyRelationAdapter> results = new ArrayList<>();
+        for (RawTable table : allTables) {
+            Collection<RawForeignKey> imported = table.getImportedKeys();
+            if (imported.size() == 2) {
+                List<RawForeignKey> importedList = new ArrayList<>(imported);
+                RawForeignKey fk1 = importedList.get(0);
+                RawForeignKey fk2 = importedList.get(1);
+                if (!fk1.getPktableName().equalsIgnoreCase(fk2.getPktableName())) {
+                    if (fk1.getPktableName().equalsIgnoreCase(rawTable.getTableName())) {
+                        results.add(
+                                createManyToManyRelation(
+                                        fk1, fk2, table.getTableName()));
+                    } else if (fk2.getPktableName().equalsIgnoreCase(rawTable.getTableName())) {
+                        results.add(
+                                createManyToManyRelation(
+                                        fk2, fk1, table.getTableName()));
+                    }
+                }
+            }
+        }
+        return results;
+    }
+
+    private ManyToManyRelationAdapter createManyToManyRelation(
+            RawForeignKey currentFk, RawForeignKey otherFk, String joinTable) {
+        String className =
+                JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(otherFk.getPktableName());
+        String fieldName =
+                JavaPropertyConverter.camelCaseFromSnakeCaseInitLow(otherFk.getPktableName())
+                        + "List";
+        String methodName =
+                JavaPropertyConverter.camelCaseFromSnakeCaseInitCap(otherFk.getPktableName())
+                        + "List";
+        return new ManyToManyRelationAdapter(
+                className,
+                fieldName,
+                methodName,
+                currentFk.getFkcolumnName(),
+                joinTable,
+                otherFk.getFkcolumnName());
     }
 }

--- a/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/ManyToManyRelationAdapter.java
+++ b/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/ManyToManyRelationAdapter.java
@@ -1,0 +1,26 @@
+package org.db2code.generator.java.pojo.adapter;
+
+public class ManyToManyRelationAdapter extends RelationAdapter {
+    private final String joinTable;
+    private final String inverseJoinColumn;
+
+    public ManyToManyRelationAdapter(
+            String targetClassName,
+            String fieldName,
+            String methodName,
+            String joinColumn,
+            String joinTable,
+            String inverseJoinColumn) {
+        super(targetClassName, fieldName, methodName, joinColumn);
+        this.joinTable = joinTable;
+        this.inverseJoinColumn = inverseJoinColumn;
+    }
+
+    public String getJoinTable() {
+        return joinTable;
+    }
+
+    public String getInverseJoinColumn() {
+        return inverseJoinColumn;
+    }
+}

--- a/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/PropertyAdapter.java
+++ b/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/PropertyAdapter.java
@@ -21,6 +21,10 @@ public class PropertyAdapter {
     private final Set<String> primaryKeyColumns;
     private String propertyName;
     private String methodName;
+    private boolean isRelational;
+    private Boolean isManyToOne;
+    private Boolean isOneToMany;
+    private String mappedBy;
 
     public PropertyAdapter(
             RawTable rawTable,
@@ -105,5 +109,37 @@ public class PropertyAdapter {
         } else {
             return null;
         }
+    }
+
+    public boolean isRelational() {
+        return isRelational;
+    }
+
+    public void setRelational(boolean relational) {
+        isRelational = relational;
+    }
+
+    public Boolean getManyToOne() {
+        return isManyToOne;
+    }
+
+    public void setManyToOne(Boolean manyToOne) {
+        isManyToOne = manyToOne;
+    }
+
+    public Boolean getOneToMany() {
+        return isOneToMany;
+    }
+
+    public void setOneToMany(Boolean oneToMany) {
+        isOneToMany = oneToMany;
+    }
+
+    public String getMappedBy() {
+        return mappedBy;
+    }
+
+    public void setMappedBy(String mappedBy) {
+        this.mappedBy = mappedBy;
     }
 }

--- a/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/RelationAdapter.java
+++ b/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/RelationAdapter.java
@@ -1,0 +1,31 @@
+package org.db2code.generator.java.pojo.adapter;
+
+public class RelationAdapter {
+    private final String targetClassName;
+    private final String fieldName;
+    private final String methodName;
+    private final String joinColumn;
+
+    public RelationAdapter(String targetClassName, String fieldName, String methodName, String joinColumn) {
+        this.targetClassName = targetClassName;
+        this.fieldName = fieldName;
+        this.methodName = methodName;
+        this.joinColumn = joinColumn;
+    }
+
+    public String getTargetClassName() {
+        return targetClassName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public String getJoinColumn() {
+        return joinColumn;
+    }
+}

--- a/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/RelationAdapter.java
+++ b/java-pojo-generator/src/main/java/org/db2code/generator/java/pojo/adapter/RelationAdapter.java
@@ -6,7 +6,8 @@ public class RelationAdapter {
     private final String methodName;
     private final String joinColumn;
 
-    public RelationAdapter(String targetClassName, String fieldName, String methodName, String joinColumn) {
+    public RelationAdapter(
+            String targetClassName, String fieldName, String methodName, String joinColumn) {
         this.targetClassName = targetClassName;
         this.fieldName = fieldName;
         this.methodName = methodName;

--- a/java-pojo-generator/src/main/resources/spring-data.mustache
+++ b/java-pojo-generator/src/main/resources/spring-data.mustache
@@ -3,6 +3,12 @@ package {{package}};
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import java.util.List;
 
 /** {{rawTable.remarks}}
     {{rawTable.tableCat}}.{{rawTable.tableSchem}}.{{rawTable.tableName}}{{#generationInfo}}
@@ -23,6 +29,29 @@ public class {{className}} {
     @jakarta.validation.constraints.Size(max = {{size}}){{/size}}
     private {{propertyType}} {{propertyName}};
     {{/properties}}
+    {{#oneToManyRelations}}
+
+    @OneToMany
+    @JoinColumn(name = "{{joinColumn}}")
+    private List<{{targetClassName}}> {{fieldName}};
+    {{/oneToManyRelations}}
+
+    {{#manyToOneRelations}}
+
+    @ManyToOne
+    @JoinColumn(name = "{{joinColumn}}")
+    private {{targetClassName}} {{fieldName}};
+    {{/manyToOneRelations}}
+
+    {{#manyToManyRelations}}
+
+    @ManyToMany
+    @JoinTable(name = "{{joinTable}}",
+        joinColumns = @JoinColumn(name = "{{joinColumn}}"),
+        inverseJoinColumns = @JoinColumn(name = "{{inverseJoinColumn}}"))
+    private List<{{targetClassName}}> {{fieldName}};
+    {{/manyToManyRelations}}
+
     {{#properties}}
 
     public {{propertyType}} get{{methodName}}() {
@@ -34,4 +63,40 @@ public class {{className}} {
     }
 
     {{/properties}}
+
+    {{#oneToManyRelations}}
+
+    public List<{{targetClassName}}> get{{methodName}}() {
+        return {{fieldName}};
+    }
+
+    public void set{{methodName}}(List<{{targetClassName}}> {{fieldName}}) {
+        this.{{fieldName}} = {{fieldName}};
+    }
+
+    {{/oneToManyRelations}}
+
+    {{#manyToOneRelations}}
+
+    public {{targetClassName}} get{{methodName}}() {
+        return {{fieldName}};
+    }
+
+    public void set{{methodName}}({{targetClassName}} {{fieldName}}) {
+        this.{{fieldName}} = {{fieldName}};
+    }
+
+    {{/manyToOneRelations}}
+
+    {{#manyToManyRelations}}
+
+    public List<{{targetClassName}}> get{{methodName}}() {
+        return {{fieldName}};
+    }
+
+    public void set{{methodName}}(List<{{targetClassName}}> {{fieldName}}) {
+        this.{{fieldName}} = {{fieldName}};
+    }
+
+    {{/manyToManyRelations}}
 }

--- a/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/SpringDataRelationsTemplateTest.java
+++ b/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/SpringDataRelationsTemplateTest.java
@@ -12,10 +12,6 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.db2code.MetadataExtractor;
 import org.db2code.extractors.DatabaseExtractionParameters;
-import org.db2code.generator.java.pojo.ClassWriter;
-import org.db2code.generator.java.pojo.Generator;
-import org.db2code.generator.java.pojo.GeneratorTarget;
-import org.db2code.generator.java.pojo.MustacheTemplatingProvider;
 import org.db2code.generator.java.pojo.adapter.DateImpl;
 import org.db2code.rawmodel.RawColumn;
 import org.db2code.rawmodel.RawDatabaseMetadata;
@@ -49,7 +45,13 @@ class SpringDataRelationsTemplateTest {
                     new ExecutorParams(
                             List.of(
                                     new DatabaseExtractionParameters(
-                                            "cat", "schem", "%", new String[] {}, null, null, false)),
+                                            "cat",
+                                            "schem",
+                                            "%",
+                                            new String[] {},
+                                            null,
+                                            null,
+                                            false)),
                             Arrays.asList("spring-data.mustache"),
                             null,
                             new GeneratorTarget("testpkg", "src", dir, null, null, null, null),
@@ -85,15 +87,11 @@ class SpringDataRelationsTemplateTest {
         RawTable join = createJoinTable("TABLE_A_C", "A_ID", tableA, "C_ID", tableC);
 
         tableA.setForeignKeys(
-                List.of(
-                        fk(tableA, "A_ID", tableB, "A_ID"),
-                        fk(tableA, "A_ID", join, "A_ID")));
+                List.of(fk(tableA, "A_ID", tableB, "A_ID"), fk(tableA, "A_ID", join, "A_ID")));
         tableB.setImportedKeys(List.of(fk(tableA, "A_ID", tableB, "A_ID")));
         tableC.setForeignKeys(List.of(fk(tableC, "C_ID", join, "C_ID")));
         join.setImportedKeys(
-                List.of(
-                        fk(tableA, "A_ID", join, "A_ID"),
-                        fk(tableC, "C_ID", join, "C_ID")));
+                List.of(fk(tableA, "A_ID", join, "A_ID"), fk(tableC, "C_ID", join, "C_ID")));
 
         RawDatabaseMetadata metadata = new RawDatabaseMetadata();
         metadata.setTables(Arrays.asList(tableA, tableB, tableC, join));
@@ -140,8 +138,7 @@ class SpringDataRelationsTemplateTest {
         return col;
     }
 
-    private RawForeignKey fk(
-            RawTable pkTable, String pkCol, RawTable fkTable, String fkCol) {
+    private RawForeignKey fk(RawTable pkTable, String pkCol, RawTable fkTable, String fkCol) {
         RawForeignKey fk = new RawForeignKey();
         fk.setPktableName(pkTable.getTableName());
         fk.setPkcolumnName(pkCol);

--- a/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/SpringDataRelationsTemplateTest.java
+++ b/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/SpringDataRelationsTemplateTest.java
@@ -1,0 +1,152 @@
+package org.db2code.generator.java.pojo;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.db2code.MetadataExtractor;
+import org.db2code.extractors.DatabaseExtractionParameters;
+import org.db2code.generator.java.pojo.ClassWriter;
+import org.db2code.generator.java.pojo.Generator;
+import org.db2code.generator.java.pojo.GeneratorTarget;
+import org.db2code.generator.java.pojo.MustacheTemplatingProvider;
+import org.db2code.generator.java.pojo.adapter.DateImpl;
+import org.db2code.rawmodel.RawColumn;
+import org.db2code.rawmodel.RawDatabaseMetadata;
+import org.db2code.rawmodel.RawForeignKey;
+import org.db2code.rawmodel.RawTable;
+import org.db2code.rawmodel.RawTable.RawPrimaryKey;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SpringDataRelationsTemplateTest {
+
+    @Test
+    void testRelations() throws Exception {
+        RawDatabaseMetadata metadata = buildMetadata();
+        MetadataExtractor metadataExtractor = mock(MetadataExtractor.class);
+        when(metadataExtractor.extract(any())).thenReturn(metadata);
+        GeneratorExecutor generatorExecutor =
+                new GeneratorExecutor(
+                        metadataExtractor,
+                        new ClassWriter(),
+                        new Generator(new MustacheTemplatingProvider()));
+        String dir =
+                Paths.get(
+                                System.getProperty("java.io.tmpdir"),
+                                "db2o-temp",
+                                Long.toString(System.currentTimeMillis()))
+                        .toString();
+        Assertions.assertTrue(new File(dir).mkdirs());
+        try {
+            generatorExecutor.execute(
+                    new ExecutorParams(
+                            List.of(
+                                    new DatabaseExtractionParameters(
+                                            "cat", "schem", "%", new String[] {}, null, null, false)),
+                            Arrays.asList("spring-data.mustache"),
+                            null,
+                            new GeneratorTarget("testpkg", "src", dir, null, null, null, null),
+                            null,
+                            DateImpl.UTIL_DATE,
+                            null,
+                            false));
+            String classA =
+                    FileUtils.readFileToString(
+                            Paths.get(dir, "src", "testpkg", "TableA.java").toFile(),
+                            Charset.defaultCharset());
+            String classB =
+                    FileUtils.readFileToString(
+                            Paths.get(dir, "src", "testpkg", "TableB.java").toFile(),
+                            Charset.defaultCharset());
+            String classC =
+                    FileUtils.readFileToString(
+                            Paths.get(dir, "src", "testpkg", "TableC.java").toFile(),
+                            Charset.defaultCharset());
+            Assertions.assertTrue(classA.contains("@OneToMany"));
+            Assertions.assertTrue(classB.contains("@ManyToOne"));
+            Assertions.assertTrue(classA.contains("@ManyToMany"));
+            Assertions.assertTrue(classC.contains("@ManyToMany"));
+        } finally {
+            FileUtils.deleteDirectory(new File(dir));
+        }
+    }
+
+    private RawDatabaseMetadata buildMetadata() {
+        RawTable tableA = createTable("TABLE_A", "A_ID");
+        RawTable tableB = createTable("TABLE_B", "B_ID");
+        RawTable tableC = createTable("TABLE_C", "C_ID");
+        RawTable join = createJoinTable("TABLE_A_C", "A_ID", tableA, "C_ID", tableC);
+
+        tableA.setForeignKeys(
+                List.of(
+                        fk(tableA, "A_ID", tableB, "A_ID"),
+                        fk(tableA, "A_ID", join, "A_ID")));
+        tableB.setImportedKeys(List.of(fk(tableA, "A_ID", tableB, "A_ID")));
+        tableC.setForeignKeys(List.of(fk(tableC, "C_ID", join, "C_ID")));
+        join.setImportedKeys(
+                List.of(
+                        fk(tableA, "A_ID", join, "A_ID"),
+                        fk(tableC, "C_ID", join, "C_ID")));
+
+        RawDatabaseMetadata metadata = new RawDatabaseMetadata();
+        metadata.setTables(Arrays.asList(tableA, tableB, tableC, join));
+        return metadata;
+    }
+
+    private RawTable createTable(String name, String idCol) {
+        RawTable table = new RawTable();
+        table.setTableName(name);
+        table.setTableType("TABLE");
+        RawColumn col = createColumn(name, idCol);
+        table.setColumns(List.of(col));
+        RawPrimaryKey pk = new RawPrimaryKey();
+        pk.setColumnName(idCol);
+        table.setPrimaryKey(List.of(pk));
+        return table;
+    }
+
+    private RawTable createJoinTable(
+            String name, String col1, RawTable ref1, String col2, RawTable ref2) {
+        RawTable table = new RawTable();
+        table.setTableName(name);
+        table.setTableType("TABLE");
+        RawColumn c1 = createColumn(name, col1);
+        RawColumn c2 = createColumn(name, col2);
+        table.setColumns(List.of(c1, c2));
+        RawPrimaryKey pk1 = new RawPrimaryKey();
+        pk1.setColumnName(col1);
+        RawPrimaryKey pk2 = new RawPrimaryKey();
+        pk2.setColumnName(col2);
+        table.setPrimaryKey(Arrays.asList(pk1, pk2));
+        return table;
+    }
+
+    private RawColumn createColumn(String tableName, String columnName) {
+        RawColumn col = new RawColumn();
+        col.setTableName(tableName);
+        col.setColumnName(columnName);
+        col.setDataType(4);
+        col.setTypeName("INTEGER");
+        col.setColumnSize(32);
+        col.setNullable(0);
+        col.setIsNullable("NO");
+        return col;
+    }
+
+    private RawForeignKey fk(
+            RawTable pkTable, String pkCol, RawTable fkTable, String fkCol) {
+        RawForeignKey fk = new RawForeignKey();
+        fk.setPktableName(pkTable.getTableName());
+        fk.setPkcolumnName(pkCol);
+        fk.setFktableName(fkTable.getTableName());
+        fk.setFkcolumnName(fkCol);
+        return fk;
+    }
+}

--- a/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/adapter/DatabaseAdapterTest.java
+++ b/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/adapter/DatabaseAdapterTest.java
@@ -1,0 +1,73 @@
+package org.db2code.generator.java.pojo.adapter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.db2code.extractors.DatabaseExtractionParameters;
+import org.db2code.generator.java.pojo.ExecutorParams;
+import org.db2code.generator.java.pojo.GeneratorTarget;
+import org.db2code.rawmodel.RawDatabaseMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DatabaseAdapterTest {
+
+    @Test
+    public void test() throws IOException {
+        RawDatabaseMetadata rawDatabaseMetadata = getRawDatabaseMetadata();
+        ExecutorParams executorParams = getExecutorParams();
+
+        DatabaseAdapter databaseAdapter = new DatabaseAdapter(rawDatabaseMetadata, executorParams);
+        Map<String, DefaultClassAdapter> classes = databaseAdapter.getClasses().stream().collect(Collectors.toMap(ClassAdapter::getClassName, claz -> (DefaultClassAdapter) claz));
+        Map<String, PropertyAdapter> tt3Properties = classes.get("TestTable3").getProperties().stream().collect(Collectors.toMap(PropertyAdapter::getPropertyName, p -> p));
+        for (PropertyAdapter tt1Property : tt3Properties.values()) {
+            System.out.println(tt1Property);
+        }
+        System.out.println(classes);
+    }
+
+    private static RawDatabaseMetadata getRawDatabaseMetadata() throws IOException {
+        byte[] mockMetadataBytes =
+                DatabaseAdapterTest.class
+                        .getResourceAsStream("/sample-metadata.json")
+                        .readAllBytes();
+        RawDatabaseMetadata rawDatabaseMetadata =
+                new ObjectMapper()
+                        .readValue(new String(mockMetadataBytes), RawDatabaseMetadata.class);
+        return rawDatabaseMetadata;
+    }
+
+    private static ExecutorParams getExecutorParams() {
+        String dir = Paths.get(
+                        System.getProperty("java.io.tmpdir"),
+                        "db2o-temp",
+                        Long.toString(System.currentTimeMillis()))
+                .toString();
+
+        ExecutorParams executorParams = new ExecutorParams(
+                Arrays.asList(
+                        new DatabaseExtractionParameters(
+                                "testcat",
+                                "testSchemaPattern",
+                                "testTablePattern",
+                                new String[]{},
+                                null,
+                                null,
+                                false)),
+                Arrays.asList("pojo.mustache"),
+                null,
+                new GeneratorTarget("testpkg", "src", dir, null, null, null, null),
+                null,
+                DateImpl.UTIL_DATE,
+                null,
+                false);
+        return executorParams;
+    }
+
+}

--- a/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/adapter/DatabaseAdapterTest.java
+++ b/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/adapter/DatabaseAdapterTest.java
@@ -1,20 +1,18 @@
 package org.db2code.generator.java.pojo.adapter;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.db2code.extractors.DatabaseExtractionParameters;
 import org.db2code.generator.java.pojo.ExecutorParams;
 import org.db2code.generator.java.pojo.GeneratorTarget;
 import org.db2code.rawmodel.RawDatabaseMetadata;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class DatabaseAdapterTest {
 
@@ -24,8 +22,15 @@ class DatabaseAdapterTest {
         ExecutorParams executorParams = getExecutorParams();
 
         DatabaseAdapter databaseAdapter = new DatabaseAdapter(rawDatabaseMetadata, executorParams);
-        Map<String, DefaultClassAdapter> classes = databaseAdapter.getClasses().stream().collect(Collectors.toMap(ClassAdapter::getClassName, claz -> (DefaultClassAdapter) claz));
-        Map<String, PropertyAdapter> tt3Properties = classes.get("TestTable3").getProperties().stream().collect(Collectors.toMap(PropertyAdapter::getPropertyName, p -> p));
+        Map<String, DefaultClassAdapter> classes =
+                databaseAdapter.getClasses().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        ClassAdapter::getClassName,
+                                        claz -> (DefaultClassAdapter) claz));
+        Map<String, PropertyAdapter> tt3Properties =
+                classes.get("TestTable3").getProperties().stream()
+                        .collect(Collectors.toMap(PropertyAdapter::getPropertyName, p -> p));
         for (PropertyAdapter tt1Property : tt3Properties.values()) {
             System.out.println(tt1Property);
         }
@@ -44,30 +49,31 @@ class DatabaseAdapterTest {
     }
 
     private static ExecutorParams getExecutorParams() {
-        String dir = Paths.get(
-                        System.getProperty("java.io.tmpdir"),
-                        "db2o-temp",
-                        Long.toString(System.currentTimeMillis()))
-                .toString();
+        String dir =
+                Paths.get(
+                                System.getProperty("java.io.tmpdir"),
+                                "db2o-temp",
+                                Long.toString(System.currentTimeMillis()))
+                        .toString();
 
-        ExecutorParams executorParams = new ExecutorParams(
-                Arrays.asList(
-                        new DatabaseExtractionParameters(
-                                "testcat",
-                                "testSchemaPattern",
-                                "testTablePattern",
-                                new String[]{},
-                                null,
-                                null,
-                                false)),
-                Arrays.asList("pojo.mustache"),
-                null,
-                new GeneratorTarget("testpkg", "src", dir, null, null, null, null),
-                null,
-                DateImpl.UTIL_DATE,
-                null,
-                false);
+        ExecutorParams executorParams =
+                new ExecutorParams(
+                        Arrays.asList(
+                                new DatabaseExtractionParameters(
+                                        "testcat",
+                                        "testSchemaPattern",
+                                        "testTablePattern",
+                                        new String[] {},
+                                        null,
+                                        null,
+                                        false)),
+                        Arrays.asList("pojo.mustache"),
+                        null,
+                        new GeneratorTarget("testpkg", "src", dir, null, null, null, null),
+                        null,
+                        DateImpl.UTIL_DATE,
+                        null,
+                        false);
         return executorParams;
     }
-
 }

--- a/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/adapter/DefaultClassAdapterTest.java
+++ b/java-pojo-generator/src/test/java/org/db2code/generator/java/pojo/adapter/DefaultClassAdapterTest.java
@@ -19,7 +19,8 @@ class DefaultClassAdapterTest {
         col2.setColumnName("test_col_");
         rawTable.setColumns(asList(col1, col2));
         DefaultClassAdapter classAdapter =
-                new DefaultClassAdapter(rawTable, null, null, null, false, null, null);
+                new DefaultClassAdapter(
+                        rawTable, null, null, null, false, null, null, java.util.List.of(rawTable));
         Collection<PropertyAdapter> properties = classAdapter.getProperties();
         Assertions.assertTrue(properties.size() == 2);
         Iterator<PropertyAdapter> iterator = properties.iterator();

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.35.0</version>
+                <version>2.44.0</version>
                 <configuration>
                     <java>
                         <toggleOffOn/>


### PR DESCRIPTION
## Summary
- support extraction of imported foreign keys
- generate one-to-many, many-to-one and many-to-many relationship fields in Spring Data templates
- add tests covering relationship templates

## Testing
- `mvn -q -e test` *(fails: Network is unreachable for maven-pmd-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6894613e5d90832cb505f160288deb38